### PR TITLE
Fix time regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ lazy_static! {
     )
     .unwrap();
     static ref TIME_RE: Regex =
-        Regex::new(r"TIME:? \d{1,2}\.\d{2} (A|P)\.M\.? [–-] \d{1,2}\.\d{2} (A|P)\.M\.?").unwrap();
+        Regex::new(r"TIME:? \d{1,2}\.\d{2}\s{0,1}(A|P)\.M\.? [–-] \d{1,2}\.\d{2}\s{0,1}(A|P)\.M\.?").unwrap();
 }
 
 pub fn extract_text_from_pdf<P>(path: P) -> Result<String, anyhow::Error>


### PR DESCRIPTION
Allow space between time and AM/PM. Case has appeared on this week's [pdf](https://www.kplc.co.ke/content/item/3879/interruptions---14.07.2022---21.07.2022) that was raising an exception due to no match.

Eg:
 `TIME: 9.00A.M – 5.00P.M` 
![image](https://user-images.githubusercontent.com/25291950/180442697-d5723584-80a0-49ee-a5e1-84ddd7d03d41.png)
